### PR TITLE
Fixed open_session

### DIFF
--- a/flask_beaker.py
+++ b/flask_beaker.py
@@ -19,7 +19,8 @@ from flask.sessions import SessionInterface
 
 class BeakerSessionInterface(SessionInterface):
     def open_session(self, app, request):
-        return request.environ['beaker.session']
+        return request.environ.get('beaker.session')
+
     def save_session(self, app, session, response):
         session.save()
 


### PR DESCRIPTION
As in docs
This method has to be implemented and must either return `None`
        in case the loading failed because of a configuration error or an
        instance of a session object which implements a dictionary like
        interface + the methods and attributes on :class:`SessionMixin`.
